### PR TITLE
request-local-storage error across linked modules

### DIFF
--- a/.reactserverrc
+++ b/.reactserverrc
@@ -1,4 +1,6 @@
 {
   "routesFile": "./routes.js",
+  "webpackClientConfig": "./config/webpack.client.config.js",
+  "webpackServerConfig": "./config/webpack.server.config.js",
   "customMiddlewarePath": "./api"
 }

--- a/config/webpack.client.config.js
+++ b/config/webpack.client.config.js
@@ -1,0 +1,7 @@
+const webpackClientConfig = require('@kununu/react-universal-scripts/kununu/config/webpack.client.config.js');
+
+module.exports = {
+  default (webpackConfig) {
+    return webpackClientConfig(webpackConfig);
+  },
+};

--- a/config/webpack.server.config.js
+++ b/config/webpack.server.config.js
@@ -1,0 +1,7 @@
+const webpackServerConfig = require('@kununu/react-universal-scripts/kununu/config/webpack.server.config.js');
+
+module.exports = {
+  default (webpackConfig) {
+    return webpackServerConfig(webpackConfig);
+  },
+};

--- a/modules.js
+++ b/modules.js
@@ -1,0 +1,3 @@
+module.exports = {
+  module1: require('@karlhorky/react-server-bike-share-example-module'),
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "react-server-bike-share-example-module": "karlhorky/react-server-bike-share-example-module#master",
     "@kununu/react-universal-scripts": "^0.8.4-prerelease.10",
     "react": "^15.4.1",
     "react-dom": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "react-server-bike-share-example-module": "karlhorky/react-server-bike-share-example-module#master",
-    "@kununu/react-universal-scripts": "^0.8.4-prerelease.10",
+    "@karlhorky/react-server-bike-share-example-module": "karlhorky/react-server-bike-share-example-module#master",
+    "@kununu/react-universal-scripts": "^0.8.4-prerelease.11",
     "react": "^15.4.1",
     "react-dom": "15.4.1",
     "request-promise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@kununu/react-universal-scripts": "^0.8.4-prerelease.10",
     "react": "^15.4.1",
     "react-dom": "15.4.1",
-    "react-server": "jhnns/react-server#6251d5c9469f3c5c97a6fb4a1f677fdc1b7fff79",
-    "react-server-cli": "jhnns/react-server-cli#3e6e324c35315e66078aaa90a3d2002eacb1453a",
     "request-promise": "^4.1.1",
     "superagent": "1.8.4"
-  },
-  "devDependencies": {
-    "babel-preset-react-server": "^0.4.4"
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -2,5 +2,5 @@ module.exports = {
 	middleware: [
 		'./middleware/request-to-port',
 	],
-	routes: require('react-server-bike-share-example-module').routes,
+	routes: require('./modules').module1.routes,
 };

--- a/routes.js
+++ b/routes.js
@@ -2,16 +2,5 @@ module.exports = {
 	middleware: [
 		'./middleware/request-to-port',
 	],
-	routes: {
-		Index: {
-			path: '/',
-			method: 'get',
-			page: './pages/index',
-		},
-		Network: {
-			path: ['/network'],
-			method: 'get',
-			page: './pages/network',
-		},
-	},
+	routes: require('react-server-bike-share-example-module').routes,
 };


### PR DESCRIPTION
Setup to reproduce:

```sh
cd projects
git clone git@github.com:karlhorky/react-server-bike-share-example.git
git clone git@github.com:karlhorky/react-server-bike-share-example-module.git
cd react-server-bike-share-example-module
npm install
npm link
cd react-server-bike-share-example
git checkout kununu-react-universal-scripts-server-side-webpack-config-breakage
npm link @karlhorky/react-server-bike-share-example-module
npm install
npm start
```

Upon visiting the route in the browser, the following error will be thrown:

```sh
➜  react-server-bike-share-example git:(kununu-react-universal-scripts-server-side-webpack-config-breakage) ✗ yarn start
yarn start v0.19.1
$ npm run clean && react-server start --hot 

> react-server-bike-share@0.0.1 clean /Users/karlhorky/projects/react-server-bike-share-example
> rm -rf build __clientTemp

2017-02-15T14:08:59.576Z - warning: [react-server-cli.src.logProductionWarnings] PRODUCTION WARNING: the following current settings are discouraged in production environments. (If you are developing, carry on!):
2017-02-15T14:08:59.578Z - warning: [react-server-cli.src.logProductionWarnings] -- Hot reload is enabled. To disable, set hot to false (--hot=false at the command-line) or set NODE_ENV=production.
2017-02-15T14:08:59.579Z - warning: [react-server-cli.src.logProductionWarnings] -- Minification is disabled. To enable, set minify to true (--minify at the command-line) or set NODE_ENV=production.
2017-02-15T14:08:59.579Z - warning: [react-server-cli.src.logProductionWarnings] -- Long-term caching is disabled. To enable, set longTermCaching to true (--long-term-caching at the command-line) or set NODE_ENV=production to turn on.
2017-02-15T14:08:59.579Z - info: [react-server-cli.src.logProductionWarnings] NODE_ENV is set to undefined
2017-02-15T14:09:00.015Z - notice: [react-server-cli.src.commands.start] Starting server...
2017-02-15T14:09:00.123Z - info: [react-server-cli.src.commands.start] Watching react-server configuration files for changes:  0=/Users/karlhorky/projects/react-server-bike-share-example/.reactserverrc, 1=/Users/karlhorky/projects/react-server-bike-share-example/routes.js, 2=/Users/karlhorky/projects/react-server-bike-share-example/config/webpack.client.config.js, 3=/Users/karlhorky/projects/react-server-bike-share-example/config/webpack.server.config.js
2017-02-15T14:09:02.962Z - info: [react-server-cli.src.commands.start] webpack built aa6bf31c7741bf7eaa4c in 2912ms
2017-02-15T14:09:03.554Z - info: [react-server-cli.src.commands.start] Starting react-server...
2017-02-15T14:09:03.945Z - info: [react-server-cli.src.commands.start] Started react-server over HTTP on 0.0.0.0:3000
2017-02-15T14:09:03.946Z - notice: [react-server-cli.src.commands.start] Ready for requests on 0.0.0.0:3000.
2017-02-15T14:09:16.159Z - debug: [react-server.core.renderMiddleware] Incoming request for /
2017-02-15T14:09:16.162Z - debug: [react-server.core.context.Navigator] Navigating to /
2017-02-15T14:09:16.163Z - debug: [react-server.core.context.Navigator] Mapped / to route Index
2017-02-15T14:09:16.608Z - debug: [react-server.core.util.PageUtil] Call setRequest
2017-02-15T14:09:16.609Z - debug: [react-server.core.util.PageUtil.PageConfig] Default "isFragment" => "false"
2017-02-15T14:09:16.609Z - debug: [react-server.core.util.PageUtil.PageConfig] Default "isRawResponse" => "false"
2017-02-15T14:09:16.609Z - debug: [react-server.core.util.PageUtil] Call addConfigValues
2017-02-15T14:09:16.610Z - debug: [react-server.core.util.PageUtil] Call setConfigValues
2017-02-15T14:09:16.610Z - debug: [react-server.core.util.PageUtil.PageConfig] Final isFragment=false, isRawResponse=false
2017-02-15T14:09:16.610Z - debug: [react-server.core.util.PageUtil] Call getRequest
2017-02-15T14:09:16.611Z - debug: [react-server.core.util.PageUtil] Call handleRoute
2017-02-15T14:09:16.612Z - info: [react-server-bike-share-example-module.pages.index] handling index
2017-02-15T14:09:16.632Z - error: [react-server.core.context.Navigator] Error while handling route message=RLS() access outside of request!, stack=Error: RLS() access outside of request!
    at /Users/karlhorky/projects/react-server-bike-share-example-module/node_modules/request-local-storage/lib/server/index.js:26:35
    at Object.cache (/Users/karlhorky/projects/react-server-bike-share-example-module/node_modules/react-server/target/server/ReactServerAgent.js:53:15)
    at Object.get (/Users/karlhorky/projects/react-server-bike-share-example-module/node_modules/react-server/target/server/ReactServerAgent.js:16:41)
    at IndexPage.handleRoute (webpack:///.-module/pages/index.js:13:17)
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/react-server/target/server/util/util/PageUtil.js:323:25
    at RequestToPortMiddleware.handleRoute (webpack:///middleware/request-to-port.js:9:3)
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/react-server/target/server/util/util/PageUtil.js:323:25
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/react-server/target/server/util/util/PageUtil.js:315:15
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/continuation-local-storage/context.js:84:17
    at _fulfilled (/Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:796:13)
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:857:14
    at runSingle (/Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:137:13)
    at flush (/Users/karlhorky/projects/react-server-bike-share-example/node_modules/q/q.js:125:13)
    at /Users/karlhorky/projects/react-server-bike-share-example/node_modules/async-listener/glue.js:188:31
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
2017-02-15T14:09:16.633Z - debug: [react-server.core.util.PageUtil] Call getHasDocument
2017-02-15T14:09:16.654Z - ok: [react-server.core.renderMiddleware] countDataRequests val=0
2017-02-15T14:09:16.654Z - ok: [react-server.core.renderMiddleware] countLateArrivals val=0
2017-02-15T14:09:16.654Z - ok: [react-server.core.renderMiddleware] bytesRead val=434
2017-02-15T14:09:16.655Z - ok: [react-server.core.renderMiddleware] bytesWritten val=350
2017-02-15T14:09:16.655Z - slow: [react-server.core.renderMiddleware] responseCode.500 ms=496
2017-02-15T14:09:16.657Z - slow: [react-server.core.renderMiddleware] totalRequestTime ms=496
2017-02-15T14:09:16.658Z - debug: [react-server.core.util.PageUtil] Call handleComplete
[object Object]
^C
```

This is apparently caused by a problem with `npm link`, because it cannot be reproduced with a normal `npm install`.

## Workarounds

- use `npm install` (not an option for us) **OR**
- work in the main repo and not the module (not an option for us) **OR**
- commenting out the server-side webpack  changes (not an option for us):

```diff
- const webpackServerConfig = require('@kununu/react-universal-scripts/kununu/config/webpack.server.config.js');
-
module.exports = {
  default (webpackConfig) {
-    return webpackServerConfig(webpackConfig);
+    return webpackConfig;
  },
};
```

## Fixes

- #3 proposes a fix to the `request-local-storage` module